### PR TITLE
Fix bug of new line charactor transformation

### DIFF
--- a/src-tauri/crates/erm/src/io/xml_format.rs
+++ b/src-tauri/crates/erm/src/io/xml_format.rs
@@ -111,16 +111,16 @@ fn is_whitespace_text(text: &BytesText<'_>) -> bool {
     text.as_ref().iter().all(u8::is_ascii_whitespace)
 }
 
-// ERM represents line breaks in managed leaf values as explicit
-// carriage-return character references instead of literal XML text.
+// Preserve each newline character in managed leaf values as an explicit XML
+// character reference instead of normalizing different newline sequences.
 fn encode_managed_newlines(text: &BytesText<'_>) -> BytesText<'static> {
     const CARRIAGE_RETURN_REFERENCE: &str = "&#x0D;";
+    const LINE_FEED_REFERENCE: &str = "&#x0A;";
 
     let escaped = std::str::from_utf8(text.as_ref()).expect("quick-xml read invalid UTF-8 text");
     let encoded = escaped
-        .replace("\r\n", CARRIAGE_RETURN_REFERENCE)
         .replace('\r', CARRIAGE_RETURN_REFERENCE)
-        .replace('\n', CARRIAGE_RETURN_REFERENCE);
+        .replace('\n', LINE_FEED_REFERENCE);
 
     BytesText::from_escaped(encoded)
 }

--- a/src-tauri/crates/erm/tests/integration/xml_preservation.rs
+++ b/src-tauri/crates/erm/tests/integration/xml_preservation.rs
@@ -369,6 +369,18 @@ fn newlines_in_unknown_elements_are_preserved() {
 }
 
 #[test]
+fn line_feed_references_in_unchanged_managed_values_are_preserved() {
+    let source = diagram_with_tables(&[table("TABLE").replace(
+        "<logical_name>TABLE</logical_name>",
+        "<logical_name>Line 1&#x0A;Line 2</logical_name>",
+    )]);
+
+    let saved = open_edit_save(&source, "unchanged_managed_line_feed", |_| {});
+
+    assert!(saved.contains("<logical_name>Line 1&#x0A;Line 2</logical_name>"));
+}
+
+#[test]
 fn mixed_text_in_managed_containers_is_preserved() {
     let source = diagram_with_tables(&[table_with_extra("OLD", "custom\ntext", "")]);
 

--- a/src-tauri/crates/erm/tests/write/serialize/diagram/diagram_walkers/diagram_walkers.rs
+++ b/src-tauri/crates/erm/tests/write/serialize/diagram/diagram_walkers/diagram_walkers.rs
@@ -17,7 +17,7 @@ fn diagram_walkers_details_are_serialized() {
 }
 
 #[test]
-fn managed_leaf_newlines_are_serialized_as_carriage_return_references() {
+fn managed_leaf_newline_characters_are_preserved_as_character_references() {
     let mut diagram = support::diagram();
     let description = "Line 1 & value\nLine 2 < value\r\nLine 3\rLine 4";
     let table = diagram
@@ -33,17 +33,14 @@ fn managed_leaf_newlines_are_serialized_as_carriage_return_references() {
         write_support::save_and_reopen_diagram(diagram, "description_newlines");
 
     assert!(content.contains(
-        "<description>Line 1 &amp; value&#x0D;Line 2 &lt; value&#x0D;Line 3&#x0D;Line 4</description>"
+        "<description>Line 1 &amp; value&#x0A;Line 2 &lt; value&#x0D;&#x0A;Line 3&#x0D;Line 4</description>"
     ));
-    assert!(content.contains("<logical_name>Members&#x0D;Master</logical_name>"));
+    assert!(content.contains("<logical_name>Members&#x0A;Master</logical_name>"));
     let reopened_table = reopened
         .diagram_walkers
         .and_then(|walkers| walkers.tables)
         .and_then(|tables| tables.into_iter().next())
         .expect("missing reopened table");
-    assert_eq!(reopened_table.logical_name, "Members\rMaster");
-    assert_eq!(
-        reopened_table.description,
-        "Line 1 & value\rLine 2 < value\rLine 3\rLine 4"
-    );
+    assert_eq!(reopened_table.logical_name, "Members\nMaster");
+    assert_eq!(reopened_table.description, description);
 }

--- a/src-tauri/crates/erm/tests/write/xml_format.rs
+++ b/src-tauri/crates/erm/tests/write/xml_format.rs
@@ -36,13 +36,13 @@ fn whitespace_only_managed_string_values_are_preserved() {
 }
 
 #[test]
-fn newline_only_managed_string_values_use_a_carriage_return_reference() {
+fn line_feed_only_managed_string_values_use_a_line_feed_reference() {
     let mut diagram = support::minimal_diagram();
     diagram.diagram_settings.database = "\n".to_string();
 
     let (content, reopened) =
         support::save_and_reopen_diagram(diagram, "newline_only_managed_string");
 
-    assert!(content.contains("<database>&#x0D;</database>"));
-    assert_eq!(reopened.diagram_settings.database, "\r");
+    assert!(content.contains("<database>&#x0A;</database>"));
+    assert_eq!(reopened.diagram_settings.database, "\n");
 }


### PR DESCRIPTION
<!--
This template is intentionally simple and abstract, as the project will be maintained by a single developer for the time being.
It will be reviewed and expanded when the project matures and external contributions become more common.
-->

## Summary

<!-- Write 1–2 lines describing the purpose of this PR -->
When saving existing erm file, `&#x0A;` is converted to `&#x0D` unnexpectedly.
https://github.com/erflute/erflute/issues/110#issuecomment-5129678944

## Changes

<!-- List the main changes made in this PR -->

- [x] Fix bug
- [x] Add test cases

## Related Issue

<!-- e.g., closes #12 -->
https://github.com/erflute/erflute/issues/110

## Notes

<!-- Optional: any additional info for reviewers -->
